### PR TITLE
Reparation du bug de couleur des characters

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,7 +11,7 @@
 @import "components/index";
 @import "pages/index";
 
-.main-container {
+.app-main-container {
   margin-left: 1rem;
   margin-right: 1rem;
   margin-top: 64px;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -9,19 +9,31 @@ $green: #1EDD88;
 $gray: #0E0000;
 $light-gray: #F4F4F4;
 
-body {
-  color:#0b4f30;
+.app-main-body {
+  color: #0b4f30;
 
   a {
     color: inherit;
-    text-decoration:none;
+    text-decoration: none;
   }
 
   a:visited {
-    color: inherit; /* Keep the original color when visited */
+    color: inherit;
   }
-  
+
   a:hover {
     color: #8EC640;
   }
+
+  h1, h2, h3, h4, h5, h6 {
+    color: inherit;
+  }
+
+  p {
+    color: inherit;
+  }
+}
+
+.white-text {
+  color: white;
 }

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,5 +1,6 @@
 // Import Google fonts
 @import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Reenie+Beanie&display=swap');
 
 // Define fonts for body and headers
 $body-font: "Work Sans", "Helvetica", "sans-serif";

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -32,14 +32,14 @@
               <% end %>
             </div>
             <div class="garden-index-info">
-              <h3><%= garden.name %></h3>
+              <h2><%= garden.name %></h2>
               <div class="garden-index-info-bottom-line">
               <p> <%= garden.size %> </p>
-                <div class="delete-garden-button">
+                <%# <div class="delete-garden-button">
                   <%= link_to  garden_path(garden), data: {turbo_method: :delete, turbo_confirm: "Êtes-vous sûr?"} do %>
-                    <i class="fa fa-trash" aria-hidden="true"></i>
+                    <%#<i class="fa fa-trash" aria-hidden="true"></i>
                   <% end %>
-                </div>
+               <%# </div>%>
               </div>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,18 +8,15 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Reenie+Beanie&display=swap" rel="stylesheet">
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="app-main-body">
         <%= render "shared/flashes" %>
     <% unless action_name == 'home' || ["registration","sessions"].include?(controller_name) %>
       <%= render "shared/navbar" %>
     <% end %>
-    <div class="main-container">
+    <div class="app-main-container">
         <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
- Reparation du bug de couleur des characters : bootstrap avait priorité sur la class general body. Solution : renommer la class global body en classe .app-main-body dans le application.scss et application.html. cette derniere est plus spécifique et prend donc le dessus.
- Rangement : déplacement de la font google utilise ds le Garden index de application.html vers la partial dedié e"_fonts.scss"
- Effacement des bouton "supprimer" sur chaque garden , dans garden index. pas utile, et c est plus sur d aller dans la garden show pour effacer un garden.